### PR TITLE
Harden supervision, fix stats log-spam, and modernize the bridge (v0.3.0)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -107,9 +107,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "bitflags"
@@ -125,9 +125,9 @@ checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "bumpalo"
-version = "3.20.2"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "bytes"
@@ -137,9 +137,9 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cc"
-version = "1.2.61"
+version = "1.2.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
+checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -317,9 +317,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "env_filter"
@@ -497,9 +497,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heck"
@@ -544,7 +544,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -563,9 +563,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
-version = "0.2.24"
+version = "0.2.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f00b5dbd620d61dfdcb6007c9c1f6054ebd75319f163d886a9055cec1155073d"
+checksum = "4603d3033e49e2b0e31229fcab20a5d40089c607d975cd9c80551dc69eed9102"
 dependencies = [
  "jiff-static",
  "log",
@@ -576,9 +576,9 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.24"
+version = "0.2.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e000de030ff8022ea1da3f466fbb0f3a809f5e51ed31f6dd931c35181ad8e6d7"
+checksum = "782d32378dddf207193ac91cefb848ad41abb58195c95168e1291227a0832b47"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -597,9 +597,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.97"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
+checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -646,15 +646,15 @@ checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
 name = "mio"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "wasi",
@@ -928,9 +928,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",
@@ -950,9 +950,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-hook-registry"
@@ -978,9 +978,9 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
  "windows-sys",
@@ -1225,9 +1225,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.120"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
+checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1238,9 +1238,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.120"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
+checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1248,9 +1248,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.120"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
+checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -1261,9 +1261,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.120"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
+checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
 dependencies = [
  "unicode-ident",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "acars-bridge"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,18 +7,28 @@ rust-version = "1.91"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = "1.0.100"
+anyhow = "1.0.102"
 async-trait = "0.1.89"
 clap = { version = "4.6.1", features = ["derive", "env"] }
-futures = "0.3.31"
-log = "0.4.29"
+futures = "0.3.32"
+log = "0.4.30"
 sdre-rust-logging = "0.3.27"
 sdre-stubborn-io = "0.7.1"
 tmq = "0.5.0"
-tokio = { version = "1.52.2", features = ["full", "tracing"] }
+tokio = { version = "1.52.3", features = ["full", "tracing"] }
 tokio-stream = "0.1.18"
 tokio-util = { version = "0.7.18", features = ["full"] }
 zmq = "0.10.0"
+
+[profile.release]
+# Best-in-class optimization for a long-running daemon: cross-crate inlining,
+# stripped symbols, no panic unwind machinery. panic = abort is safe here
+# because the supervisor architecture treats every error as a Result; nothing
+# in the code path relies on unwinding to recover.
+lto = "thin"
+codegen-units = 1
+strip = "symbols"
+panic = "abort"
 
 [lints.clippy]
 pedantic = { level = "deny", priority = -1 }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,10 @@ tokio = { version = "1.52.2", features = ["full", "tracing"] }
 tokio-stream = "0.1.18"
 tokio-util = { version = "0.7.18", features = ["full"] }
 zmq = "0.10.0"
+
+[lints.clippy]
+pedantic = { level = "deny", priority = -1 }
+nursery = { level = "deny", priority = -1 }
+style = { level = "deny", priority = -1 }
+correctness = { level = "deny", priority = -1 }
+all = { level = "deny", priority = -1 }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "acars-bridge"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2024"
 rust-version = "1.91"
 

--- a/README.md
+++ b/README.md
@@ -28,15 +28,17 @@ Every flag may also be supplied via the matching environment variable.
 
 ### Resilience
 
-Each side (input, output, stats) runs under its own supervisor task. If a side exits with an error it is restarted with exponential backoff (1s → 60s, reset after 60s of stable runtime). A graceful peer disconnect is not treated as an error and does not trigger a restart loop.
+Each side (input, output) runs under its own supervisor task, and stats runs as its own task. Behavior on exit:
+
+- **Input supervisor**: any inner exit (graceful peer close or error) triggers a reconnect with exponential backoff (1s → 60s, reset after 60s of stable runtime). Decoders may restart, and the bridge should reconnect to them automatically.
+- **Output supervisor**: an I/O error triggers a reconnect with the same exponential backoff. A graceful exit (only possible when the bridge channel has been closed during shutdown) is terminal — the supervisor does not restart.
 
 ### Graceful shutdown
 
 acars-bridge handles `SIGINT` (Ctrl-C) and `SIGTERM` with a coordinated drain:
 
-1. The shutdown signal is broadcast to all tasks.
-2. The input task is joined first so no new messages enter the bridge channel.
-3. The output task drains any remaining queued messages, then exits.
-4. The stats task flushes a final stats line and exits.
+1. The shutdown signal cancels the input supervisor; its current connection attempt or read loop is aborted, and it exits its loop without restarting.
+2. main joins the input supervisor, then drops its master clone of the bridge channel `Sender`. The output's `recv()` continues to return queued messages until the channel is empty, at which point it returns `None` and `watch_queue` exits with `Ok(())`. The output supervisor treats that as terminal and exits without restarting. The output supervisor's inner task is **not** cancelled by the shutdown signal, so buffered messages are not dropped.
+3. main joins the output supervisor, then drops its master clone of the stats channel `Sender`. The stats watcher's `recv()` returns `None` and it exits.
 
-The process then returns `0`. There is no shutdown timeout; if you need to force-exit, send a second signal and the runtime will abort.
+The process then returns `0`. There is no shutdown timeout; if you need to force-exit (for example, if the output is stuck mid-reconnect with messages still queued), send a second signal and the runtime will abort.

--- a/README.md
+++ b/README.md
@@ -8,15 +8,35 @@ acars-bridge can be used to connect to a running SDR-E container and bridge the 
 
 Note, bridge is only set up to actively connect to the source/destination, not to listen for incoming connections.
 
+If no destination is configured, the bridge still runs the input side and periodically logs receive statistics; this is useful for quickly verifying that a decoder is producing data.
+
 ### Command line flags
 
-| Flag                     | Description                                                                    | Default |
-| ------------------------ | ------------------------------------------------------------------------------ | ------- |
-| `--log-level`            | Log level to use. `info`, `debug`, and `trace` are valid inputs.               | `info`  |
-| `--source-host`          | Hostname or IP address where the decoder is getting data from.                 | `unset` |
-| `--source-port`          | Port where the decoder is getting data from.                                   | `unset` |
-| `--source-protocol`      | Protocol to use for the source. `udp`, `tcp`, and `zmq` are valid inputs.      | `unset` |
-| `--destination-host`     | Hostname or IP address where acars_router is running.                          | `unset` |
-| `--destination-port`     | Port where acars_router is running.                                            | `unset` |
-| `--destination-protocol` | Protocol to use for the destination. `udp`, `tcp`, and `zmq` are valid inputs. | `unset` |
-| `--stats-interval`       | Interval in minutes to output stats to the log.                                | `5`     |
+Every flag may also be supplied via the matching environment variable.
+
+| Flag                     | Env var                   | Description                                                                                                                                                | Default |
+| ------------------------ | ------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
+| `--log-level`            | `AB_LOG_LEVEL`            | Log level. `info`, `debug`, and `trace` are valid inputs.                                                                                                  | `info`  |
+| `--source-host`          | `AB_SOURCE`               | Hostname or IP address where the decoder is sending data from. **Required.**                                                                               | _unset_ |
+| `--source-port`          | `AB_SOURCE_PORT`          | Port where the decoder is sending data from. **Required.**                                                                                                 | _unset_ |
+| `--source-protocol`      | `AB_SOURCE_PROTOCOL`      | Protocol to use for the source. `udp`, `tcp`, or `zmq`. **Required.**                                                                                      | _unset_ |
+| `--destination-host`     | `AB_DESTINATION`          | Hostname or IP address where acars_router is running. Optional; enables the output side.                                                                   | _unset_ |
+| `--destination-port`     | `AB_DESTINATION_PORT`     | Port where acars_router is running. Required if `--destination-host` is set.                                                                               | _unset_ |
+| `--destination-protocol` | `AB_DESTINATION_PROTOCOL` | Protocol to use for the destination. `udp`, `tcp`, or `zmq`. Required if `--destination-host` is set.                                                      | _unset_ |
+| `--stat-interval`        | `AB_STAT_INTERVAL`        | Interval in minutes to output stats to the log. Must be `>= 1`.                                                                                            | `5`     |
+| `--channel-capacity`     | `AB_CHANNEL_CAPACITY`     | Capacity of the internal mpsc channels (input→output bridge and stats). Higher values absorb more burstiness before backpressure kicks in. Must be `>= 1`. | `1024`  |
+
+### Resilience
+
+Each side (input, output, stats) runs under its own supervisor task. If a side exits with an error it is restarted with exponential backoff (1s → 60s, reset after 60s of stable runtime). A graceful peer disconnect is not treated as an error and does not trigger a restart loop.
+
+### Graceful shutdown
+
+acars-bridge handles `SIGINT` (Ctrl-C) and `SIGTERM` with a coordinated drain:
+
+1. The shutdown signal is broadcast to all tasks.
+2. The input task is joined first so no new messages enter the bridge channel.
+3. The output task drains any remaining queued messages, then exits.
+4. The stats task flushes a final stats line and exits.
+
+The process then returns `0`. There is no shutdown timeout; if you need to force-exit, send a second signal and the runtime will abort.

--- a/README.md
+++ b/README.md
@@ -41,4 +41,4 @@ acars-bridge handles `SIGINT` (Ctrl-C) and `SIGTERM` with a coordinated drain:
 2. main joins the input supervisor, then drops its master clone of the bridge channel `Sender`. The output's `recv()` continues to return queued messages until the channel is empty, at which point it returns `None` and `watch_queue` exits with `Ok(())`. The output supervisor treats that as terminal and exits without restarting. The output supervisor's inner task is **not** cancelled by the shutdown signal, so buffered messages are not dropped.
 3. main joins the output supervisor, then drops its master clone of the stats channel `Sender`. The stats watcher's `recv()` returns `None` and it exits.
 
-The process then returns `0`. There is no shutdown timeout; if you need to force-exit (for example, if the output is stuck mid-reconnect with messages still queued), send a second signal and the runtime will abort.
+The process then returns `0`. There is no shutdown timeout and no second-signal force-abort handler; if you need to force-exit (for example, if the output is stuck mid-reconnect with messages still queued), send `SIGQUIT` (Ctrl-\\) or `SIGKILL`.

--- a/src/config.rs
+++ b/src/config.rs
@@ -31,6 +31,14 @@ pub struct Config {
 
     #[clap(long, env = "AB_STAT_INTERVAL", default_value = "5", value_parser = clap::value_parser!(u64).range(1..))]
     pub stat_interval: u64,
+
+    /// Capacity of the internal mpsc channels (bridge input->output and
+    /// stats). Higher values absorb more burstiness before backpressure
+    /// kicks in; lower values backpressure faster. The default is suitable
+    /// for moderate ACARS rates; tune up if you see TCP input
+    /// backpressuring upstream during output stalls.
+    #[clap(long, env = "AB_CHANNEL_CAPACITY", default_value = "1024", value_parser = clap::value_parser!(u64).range(1..))]
+    pub channel_capacity: u64,
 }
 
 impl Config {
@@ -43,6 +51,7 @@ impl Config {
         debug!("Destination Port: {:?}", self.destination_port);
         debug!("Destination Protocol: {:?}", self.destination_protocol);
         debug!("Stat Interval: {}", self.stat_interval);
+        debug!("Channel Capacity: {}", self.channel_capacity);
         debug!("Would start output server: {}", self.is_destination_set());
     }
 
@@ -84,6 +93,14 @@ impl Config {
     #[must_use]
     pub const fn get_stat_interval(&self) -> u64 {
         self.stat_interval
+    }
+
+    #[must_use]
+    pub fn get_channel_capacity(&self) -> usize {
+        // Stored as u64 for clap range validation; mpsc::channel wants usize.
+        // On a 32-bit platform a pathologically huge value gets clamped to
+        // usize::MAX rather than wrapping.
+        usize::try_from(self.channel_capacity).unwrap_or(usize::MAX)
     }
 
     #[must_use]

--- a/src/config.rs
+++ b/src/config.rs
@@ -3,8 +3,6 @@
 // Licensed under the MIT license: https://opensource.org/licenses/MIT
 // Permission is granted to use, copy, modify, and redistribute the work.
 // Full license information available in the project LICENSE file.
-pub extern crate clap as clap;
-extern crate sdre_rust_logging;
 use clap::Parser;
 
 #[derive(Parser, Debug, Clone, Default)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -31,7 +31,7 @@ pub struct Config {
     #[clap(long, env = "AB_DESTINATION_PROTOCOL")]
     pub destination_protocol: Option<String>,
 
-    #[clap(long, env = "AB_STAT_INTERVAL", default_value = "5")]
+    #[clap(long, env = "AB_STAT_INTERVAL", default_value = "5", value_parser = clap::value_parser!(u64).range(1..))]
     pub stat_interval: u64,
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 Fred Clausen
+// Copyright (c) 2024-2026 Fred Clausen
 //
 // Licensed under the MIT license: https://opensource.org/licenses/MIT
 // Permission is granted to use, copy, modify, and redistribute the work.

--- a/src/main.rs
+++ b/src/main.rs
@@ -136,11 +136,21 @@ fn spawn_input(
 /// the supervisor and borrowed mutably into `watch_queue` for each restart.
 /// Because the master `Sender<String>` lives in main, the receiver normally
 /// never sees a `None`. During shutdown, main drops its master Sender after
-/// the input supervisors exit, which lets the output drain naturally before
-/// receiving `None` and exiting.
+/// the input supervisor exits, which lets the output drain naturally before
+/// receiving `None` and returning `Ok(())` from `watch_queue`.
 ///
-/// On `cancel`, the supervisor aborts any in-flight inner task and exits its
-/// loop. The returned `JoinHandle` resolves once the supervisor has exited.
+/// Unlike `spawn_input`, the output supervisor does NOT include the cancel
+/// token in its inner `select!`. Aborting the inner task on cancel would
+/// drop any messages already buffered in the bridge channel. Instead,
+/// shutdown is driven by closing the channel: `recv()` returns `None`,
+/// `watch_queue` returns `Ok(())`, and the supervisor treats `Ok(())` as a
+/// terminal exit (no restart). The cancel token is still honored during the
+/// backoff sleep so a shutdown signal received while the output is between
+/// reconnect attempts breaks out promptly.
+///
+/// On an `Err` from `watch_queue` (real I/O failure) the supervisor restarts
+/// with exponential backoff. The returned `JoinHandle` resolves once the
+/// supervisor has exited.
 fn spawn_output(
     proto: SocketType,
     host: String,
@@ -154,40 +164,34 @@ fn spawn_output(
         while !cancel.is_cancelled() {
             let started = tokio::time::Instant::now();
 
-            let work = async {
-                match &proto {
-                    SocketType::Tcp => {
-                        let server =
-                            OutputServerOptions::<StubbornIo<TcpStream>>::new(&host, port).await?;
-                        server.watch_queue(&mut receiver).await
-                    }
-                    SocketType::Udp => {
-                        let server =
-                            OutputServerOptions::<tokio::net::UdpSocket>::new(&host, port).await?;
-                        server.watch_queue(&mut receiver).await
-                    }
-                    SocketType::Zmq => {
-                        let server = OutputServerOptions::<Publish>::new(&host, port).await?;
-                        server.watch_queue(&mut receiver).await
+            let result: Result<()> = match &proto {
+                SocketType::Tcp => {
+                    match OutputServerOptions::<StubbornIo<TcpStream>>::new(&host, port).await {
+                        Ok(server) => server.watch_queue(&mut receiver).await,
+                        Err(e) => Err(e),
                     }
                 }
-            };
-
-            let result: Option<Result<()>> = tokio::select! {
-                biased;
-                () = cancel.cancelled() => None,
-                r = work => Some(r),
+                SocketType::Udp => {
+                    match OutputServerOptions::<tokio::net::UdpSocket>::new(&host, port).await {
+                        Ok(server) => server.watch_queue(&mut receiver).await,
+                        Err(e) => Err(e),
+                    }
+                }
+                SocketType::Zmq => match OutputServerOptions::<Publish>::new(&host, port).await {
+                    Ok(server) => server.watch_queue(&mut receiver).await,
+                    Err(e) => Err(e),
+                },
             };
 
             match result {
-                None => {
-                    info!("[SUPERVISOR][{label}] Cancelled; exiting");
+                Ok(()) => {
+                    // Terminal exit: watch_queue only returns Ok(()) when the
+                    // bridge channel has been closed, which happens during
+                    // graceful shutdown. Do not restart.
+                    info!("[SUPERVISOR][{label}] Channel closed; exiting (no restart)");
                     break;
                 }
-                Some(Ok(())) => {
-                    info!("[SUPERVISOR][{label}] Task exited gracefully; restarting");
-                }
-                Some(Err(e)) => {
+                Err(e) => {
                     error!("[SUPERVISOR][{label}] Task failed: {e}; restarting");
                 }
             }
@@ -315,7 +319,7 @@ async fn main() -> Result<()> {
     // Wait for a shutdown signal.
     shutdown_signal().await;
 
-    info!("[SHUTDOWN] Cancelling supervisors");
+    info!("[SHUTDOWN] Cancelling input supervisor");
     cancel.cancel();
 
     // Drain order:
@@ -324,8 +328,12 @@ async fn main() -> Result<()> {
     //      via the cancel token, and its loop breaks before it can respawn.
     //   2. Drop the master bridge Sender. Now no Sender for the bridge
     //      channel exists; the output's recv() will return None once the
-    //      buffered messages are drained.
-    //   3. Wait for the output supervisor to drain and exit.
+    //      buffered messages are drained. The output supervisor does NOT
+    //      honor the cancel token inside its inner work (see spawn_output),
+    //      so the drain happens uninterrupted.
+    //   3. Wait for the output supervisor to drain and exit. watch_queue
+    //      returns Ok(()) on channel close and the supervisor treats that as
+    //      terminal (no restart).
     //   4. Drop the master stats Sender. The stats watcher's recv() will
     //      return None and it exits cleanly.
     if let Err(e) = input_handle.await {

--- a/src/main.rs
+++ b/src/main.rs
@@ -190,9 +190,7 @@ async fn main() -> Result<()> {
 
     let stats = stats::Stats::new(stats_receiver);
     let print_interval = config.get_stat_interval();
-    tokio::spawn(async move {
-        stats.run(print_interval);
-    });
+    stats.run(print_interval);
 
     // Spawn the supervised input.
     info!("Creating input server");

--- a/src/main.rs
+++ b/src/main.rs
@@ -172,12 +172,14 @@ async fn main() -> Result<()> {
     config.get_log_level().enable_logging();
     config.show_config();
 
+    let channel_capacity = config.get_channel_capacity();
+
     // Master bridge channel (input -> output). We retain the master Sender in
     // main so that even if all input tasks die simultaneously, the output side
     // does not see a closed channel.
     let (bridge_sender_master, bridge_receiver) = if config.is_destination_set() {
         info!("Destination set, creating output channel");
-        let (tx, rx) = mpsc::channel::<String>(32);
+        let (tx, rx) = mpsc::channel::<String>(channel_capacity);
         (Some(tx), Some(rx))
     } else {
         (None, None)
@@ -186,7 +188,7 @@ async fn main() -> Result<()> {
     // Master stats channel. Same reasoning: the master Sender stays in main so
     // the stats receiver loop never observes a closed channel due to a dead
     // input task.
-    let (stats_sender_master, stats_receiver) = mpsc::channel::<u8>(32);
+    let (stats_sender_master, stats_receiver) = mpsc::channel::<u8>(channel_capacity);
 
     let stats = stats::Stats::new(stats_receiver);
     let print_interval = config.get_stat_interval();

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 Fred Clausen
+// Copyright (c) 2024-2026 Fred Clausen
 //
 // Licensed under the MIT license: https://opensource.org/licenses/MIT
 // Permission is granted to use, copy, modify, and redistribute the work.
@@ -29,13 +29,142 @@ use clap::Parser;
 use sdre_rust_logging::SetupLogging;
 use sdre_stubborn_io::tokio::StubbornIo;
 use serverconfig::InputServerOptions;
+use std::time::Duration;
 use tmq::publish::Publish;
 use tmq::subscribe::Subscribe;
 use tokio::net::TcpStream;
 use tokio::sync::mpsc;
+use tokio::sync::mpsc::Sender;
 
 use crate::config::Config;
 use crate::serverconfig::{InputServer, OutputServer, OutputServerOptions, SocketType};
+
+/// Spawn a supervised input server. `output_sender` is the master Sender clone
+/// for the input->output bridge channel (None when no output is configured).
+/// `stats_sender` is the master Sender clone for the stats channel. Both are
+/// cloned for every (re)spawn so the master copies in main keep the channels
+/// alive even when the input task dies.
+///
+/// Backoff: 1s, 2s, 4s, 8s, 16s, 32s, then capped at 60s. Resets to 1s after
+/// the task survives for at least 60s, so a transient failure doesn't keep us
+/// in the slow-retry regime forever.
+fn spawn_input(
+    proto: SocketType,
+    host: String,
+    port: u16,
+    output_sender: Option<Sender<String>>,
+    stats_sender: Sender<u8>,
+) {
+    let label = format!("input/{host}:{port}");
+    tokio::spawn(async move {
+        let mut backoff_secs: u64 = 1;
+        loop {
+            let started = tokio::time::Instant::now();
+            let output_sender = output_sender.clone();
+            let stats_sender = stats_sender.clone();
+            let result: Result<()> = async {
+                match &proto {
+                    SocketType::Tcp => {
+                        let server = InputServerOptions::<StubbornIo<TcpStream>>::new(
+                            &host,
+                            port,
+                            output_sender,
+                            stats_sender,
+                        )
+                        .await?;
+                        server.receive_message().await?;
+                        Ok(())
+                    }
+                    SocketType::Udp => {
+                        let server = InputServerOptions::<tokio::net::UdpSocket>::new(
+                            &host,
+                            port,
+                            output_sender,
+                            stats_sender,
+                        )
+                        .await?;
+                        server.receive_message().await?;
+                        Ok(())
+                    }
+                    SocketType::Zmq => {
+                        let server = InputServerOptions::<Subscribe>::new(
+                            &host,
+                            port,
+                            output_sender,
+                            stats_sender,
+                        )
+                        .await?;
+                        server.receive_message().await?;
+                        Ok(())
+                    }
+                }
+            }
+            .await;
+
+            match result {
+                Ok(()) => info!("[SUPERVISOR][{label}] Task exited gracefully; restarting"),
+                Err(e) => error!("[SUPERVISOR][{label}] Task failed: {e}; restarting"),
+            }
+
+            if started.elapsed() >= Duration::from_secs(60) {
+                backoff_secs = 1;
+            }
+
+            info!("[SUPERVISOR][{label}] Sleeping {backoff_secs}s before restart");
+            tokio::time::sleep(Duration::from_secs(backoff_secs)).await;
+            backoff_secs = (backoff_secs.saturating_mul(2)).min(60);
+        }
+    });
+}
+
+/// Spawn a supervised output server. The output `Receiver<String>` is owned by
+/// the supervisor and borrowed mutably into `watch_queue` for each restart.
+/// Because the master `Sender<String>` lives in main, the receiver never sees
+/// a `None` from a closed channel even if the input task dies.
+fn spawn_output(proto: SocketType, host: String, port: u16, mut receiver: mpsc::Receiver<String>) {
+    let label = format!("output/{host}:{port}");
+    tokio::spawn(async move {
+        let mut backoff_secs: u64 = 1;
+        loop {
+            let started = tokio::time::Instant::now();
+            let result: Result<()> = async {
+                match &proto {
+                    SocketType::Tcp => {
+                        let server =
+                            OutputServerOptions::<StubbornIo<TcpStream>>::new(&host, port).await?;
+                        server.watch_queue(&mut receiver).await?;
+                        Ok(())
+                    }
+                    SocketType::Udp => {
+                        let server =
+                            OutputServerOptions::<tokio::net::UdpSocket>::new(&host, port).await?;
+                        server.watch_queue(&mut receiver).await?;
+                        Ok(())
+                    }
+                    SocketType::Zmq => {
+                        let server = OutputServerOptions::<Publish>::new(&host, port).await?;
+                        server.watch_queue(&mut receiver).await?;
+                        Ok(())
+                    }
+                }
+            }
+            .await;
+
+            match result {
+                Ok(()) => info!("[SUPERVISOR][{label}] Task exited gracefully; restarting"),
+                Err(e) => error!("[SUPERVISOR][{label}] Task failed: {e}; restarting"),
+            }
+
+            if started.elapsed() >= Duration::from_secs(60) {
+                backoff_secs = 1;
+            }
+
+            info!("[SUPERVISOR][{label}] Sleeping {backoff_secs}s before restart");
+            tokio::time::sleep(Duration::from_secs(backoff_secs)).await;
+            backoff_secs = (backoff_secs.saturating_mul(2)).min(60);
+        }
+    });
+}
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -43,118 +172,69 @@ async fn main() -> Result<()> {
     config.get_log_level().enable_logging();
     config.show_config();
 
-    let mut input = None;
-    let output = if config.is_destination_set() {
+    // Master bridge channel (input -> output). We retain the master Sender in
+    // main so that even if all input tasks die simultaneously, the output side
+    // does not see a closed channel.
+    let (bridge_sender_master, bridge_receiver) = if config.is_destination_set() {
         info!("Destination set, creating output channel");
-        let (input_sender, input_receiver) = mpsc::channel(32);
-        input = Some(input_sender);
-        Some(input_receiver)
+        let (tx, rx) = mpsc::channel::<String>(32);
+        (Some(tx), Some(rx))
     } else {
-        None
+        (None, None)
     };
 
-    // Create the stats channel
+    // Master stats channel. Same reasoning: the master Sender stays in main so
+    // the stats receiver loop never observes a closed channel due to a dead
+    // input task.
+    let (stats_sender_master, stats_receiver) = mpsc::channel::<u8>(32);
 
-    let (stats_input, stats_output) = mpsc::channel(32);
-    let stats = stats::Stats::new(stats_output);
-
+    let stats = stats::Stats::new(stats_receiver);
     let print_interval = config.get_stat_interval();
-
     tokio::spawn(async move {
         stats.run(print_interval);
     });
-    // create the input server
 
+    // Spawn the supervised input.
     info!("Creating input server");
-    match SocketType::try_from(config.get_source_protocol()) {
-        Ok(SocketType::Tcp) => {
-            let input_server = InputServerOptions::<StubbornIo<TcpStream>>::new(
-                config.get_source_host(),
-                config.get_source_port(),
-                input,
-                stats_input,
-            )
-            .await?;
+    let input_proto = SocketType::try_from(config.get_source_protocol())
+        .map_err(|e| anyhow::anyhow!("Error parsing source protocol: {e}"))?;
+    spawn_input(
+        input_proto,
+        config.get_source_host().to_string(),
+        config.get_source_port(),
+        bridge_sender_master.clone(),
+        stats_sender_master.clone(),
+    );
 
-            tokio::spawn(async move {
-                input_server.receive_message().await;
-            });
-        }
-        Ok(SocketType::Udp) => {
-            let input_server = InputServerOptions::<tokio::net::UdpSocket>::new(
-                config.get_source_host(),
-                config.get_source_port(),
-                input,
-                stats_input,
-            )
-            .await?;
-
-            tokio::spawn(async move {
-                input_server.receive_message().await;
-            });
-        }
-        Ok(SocketType::Zmq) => {
-            let input_server = InputServerOptions::<Subscribe>::new(
-                config.get_source_host(),
-                config.get_source_port(),
-                input,
-                stats_input,
-            )
-            .await?;
-
-            tokio::spawn(async move {
-                input_server.receive_message().await;
-            });
-        }
-        Err(e) => {
-            panic!("Error creating input server: {e}");
-        }
-    }
-
-    // create the output server
-
+    // Spawn the supervised output, if configured.
     if config.is_destination_set() {
-        let output = output.unwrap_or_else(|| panic!("Output channel not created"));
-
-        let host = config.get_destination_host().clone().unwrap();
-        let port = config.get_destination_port().unwrap();
-        let proto = config.get_destination_protocol().clone().unwrap();
+        let rx = bridge_receiver.expect("bridge receiver should exist when destination is set");
+        let host = config
+            .get_destination_host()
+            .clone()
+            .expect("destination host should be set");
+        let port = config
+            .get_destination_port()
+            .expect("destination port should be set");
+        let proto_str = config
+            .get_destination_protocol()
+            .clone()
+            .expect("destination protocol should be set");
+        let output_proto = SocketType::try_from(proto_str)
+            .map_err(|e| anyhow::anyhow!("Error parsing destination protocol: {e}"))?;
 
         info!("Creating output server");
-
-        match SocketType::try_from(proto) {
-            Ok(SocketType::Tcp) => {
-                let output_server =
-                    OutputServerOptions::<StubbornIo<TcpStream>>::new(&host, port, output).await?;
-
-                tokio::spawn(async move {
-                    output_server.watch_queue().await;
-                });
-            }
-            Ok(SocketType::Udp) => {
-                let output_server =
-                    OutputServerOptions::<tokio::net::UdpSocket>::new(&host, port, output).await?;
-
-                tokio::spawn(async move {
-                    output_server.watch_queue().await;
-                });
-            }
-            Ok(SocketType::Zmq) => {
-                let output_server =
-                    OutputServerOptions::<Publish>::new(&host, port, output).await?;
-
-                tokio::spawn(async move {
-                    output_server.watch_queue().await;
-                });
-            }
-
-            Err(e) => {
-                panic!("Error creating output server: {e}");
-            }
-        }
+        spawn_output(output_proto, host, port, rx);
     }
 
+    // Keep master Senders alive for the lifetime of the process by holding
+    // them here. Without these bindings the compiler would drop them at the
+    // end of `main`'s setup and close the channels we just worked to keep
+    // open.
+    let _bridge_keepalive = bridge_sender_master;
+    let _stats_keepalive = stats_sender_master;
+
     loop {
-        tokio::time::sleep(tokio::time::Duration::from_secs(10)).await;
+        tokio::time::sleep(Duration::from_secs(10)).await;
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -216,7 +216,7 @@ async fn main() -> Result<()> {
             .expect("destination port should be set");
         let proto_str = config
             .get_destination_protocol()
-            .clone()
+            .as_deref()
             .expect("destination protocol should be set");
         let output_proto = SocketType::try_from(proto_str)
             .map_err(|e| anyhow::anyhow!("Error parsing destination protocol: {e}"))?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,15 +4,6 @@
 // Permission is granted to use, copy, modify, and redistribute the work.
 // Full license information available in the project LICENSE file.
 
-#![deny(
-    clippy::pedantic,
-    //clippy::cargo,
-    clippy::nursery,
-    clippy::style,
-    clippy::correctness,
-    clippy::all
-)]
-
 #[macro_use]
 extern crate log;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,6 +35,8 @@ use tmq::subscribe::Subscribe;
 use tokio::net::TcpStream;
 use tokio::sync::mpsc;
 use tokio::sync::mpsc::Sender;
+use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
 
 use crate::config::Config;
 use crate::serverconfig::{InputServer, OutputServer, OutputServerOptions, SocketType};
@@ -48,21 +50,26 @@ use crate::serverconfig::{InputServer, OutputServer, OutputServerOptions, Socket
 /// Backoff: 1s, 2s, 4s, 8s, 16s, 32s, then capped at 60s. Resets to 1s after
 /// the task survives for at least 60s, so a transient failure doesn't keep us
 /// in the slow-retry regime forever.
+///
+/// On `cancel`, the supervisor aborts any in-flight inner task and exits its
+/// loop. The returned `JoinHandle` resolves once the supervisor has exited.
 fn spawn_input(
     proto: SocketType,
     host: String,
     port: u16,
     output_sender: Option<Sender<String>>,
     stats_sender: Sender<u8>,
-) {
+    cancel: CancellationToken,
+) -> JoinHandle<()> {
     let label = format!("input/{host}:{port}");
     tokio::spawn(async move {
         let mut backoff_secs: u64 = 1;
-        loop {
+        while !cancel.is_cancelled() {
             let started = tokio::time::Instant::now();
             let output_sender = output_sender.clone();
             let stats_sender = stats_sender.clone();
-            let result: Result<()> = async {
+
+            let work = async {
                 match &proto {
                     SocketType::Tcp => {
                         let server = InputServerOptions::<StubbornIo<TcpStream>>::new(
@@ -72,8 +79,7 @@ fn spawn_input(
                             stats_sender,
                         )
                         .await?;
-                        server.receive_message().await?;
-                        Ok(())
+                        server.receive_message().await
                     }
                     SocketType::Udp => {
                         let server = InputServerOptions::<tokio::net::UdpSocket>::new(
@@ -83,8 +89,7 @@ fn spawn_input(
                             stats_sender,
                         )
                         .await?;
-                        server.receive_message().await?;
-                        Ok(())
+                        server.receive_message().await
                     }
                     SocketType::Zmq => {
                         let server = InputServerOptions::<Subscribe>::new(
@@ -94,16 +99,28 @@ fn spawn_input(
                             stats_sender,
                         )
                         .await?;
-                        server.receive_message().await?;
-                        Ok(())
+                        server.receive_message().await
                     }
                 }
-            }
-            .await;
+            };
+
+            let result: Option<Result<()>> = tokio::select! {
+                biased;
+                () = cancel.cancelled() => None,
+                r = work => Some(r),
+            };
 
             match result {
-                Ok(()) => info!("[SUPERVISOR][{label}] Task exited gracefully; restarting"),
-                Err(e) => error!("[SUPERVISOR][{label}] Task failed: {e}; restarting"),
+                None => {
+                    info!("[SUPERVISOR][{label}] Cancelled; exiting");
+                    break;
+                }
+                Some(Ok(())) => {
+                    info!("[SUPERVISOR][{label}] Task exited gracefully; restarting");
+                }
+                Some(Err(e)) => {
+                    error!("[SUPERVISOR][{label}] Task failed: {e}; restarting");
+                }
             }
 
             if started.elapsed() >= Duration::from_secs(60) {
@@ -111,48 +128,77 @@ fn spawn_input(
             }
 
             info!("[SUPERVISOR][{label}] Sleeping {backoff_secs}s before restart");
-            tokio::time::sleep(Duration::from_secs(backoff_secs)).await;
+            tokio::select! {
+                biased;
+                () = cancel.cancelled() => {
+                    info!("[SUPERVISOR][{label}] Cancelled during backoff; exiting");
+                    break;
+                }
+                () = tokio::time::sleep(Duration::from_secs(backoff_secs)) => {}
+            }
             backoff_secs = (backoff_secs.saturating_mul(2)).min(60);
         }
-    });
+    })
 }
 
 /// Spawn a supervised output server. The output `Receiver<String>` is owned by
 /// the supervisor and borrowed mutably into `watch_queue` for each restart.
-/// Because the master `Sender<String>` lives in main, the receiver never sees
-/// a `None` from a closed channel even if the input task dies.
-fn spawn_output(proto: SocketType, host: String, port: u16, mut receiver: mpsc::Receiver<String>) {
+/// Because the master `Sender<String>` lives in main, the receiver normally
+/// never sees a `None`. During shutdown, main drops its master Sender after
+/// the input supervisors exit, which lets the output drain naturally before
+/// receiving `None` and exiting.
+///
+/// On `cancel`, the supervisor aborts any in-flight inner task and exits its
+/// loop. The returned `JoinHandle` resolves once the supervisor has exited.
+fn spawn_output(
+    proto: SocketType,
+    host: String,
+    port: u16,
+    mut receiver: mpsc::Receiver<String>,
+    cancel: CancellationToken,
+) -> JoinHandle<()> {
     let label = format!("output/{host}:{port}");
     tokio::spawn(async move {
         let mut backoff_secs: u64 = 1;
-        loop {
+        while !cancel.is_cancelled() {
             let started = tokio::time::Instant::now();
-            let result: Result<()> = async {
+
+            let work = async {
                 match &proto {
                     SocketType::Tcp => {
                         let server =
                             OutputServerOptions::<StubbornIo<TcpStream>>::new(&host, port).await?;
-                        server.watch_queue(&mut receiver).await?;
-                        Ok(())
+                        server.watch_queue(&mut receiver).await
                     }
                     SocketType::Udp => {
                         let server =
                             OutputServerOptions::<tokio::net::UdpSocket>::new(&host, port).await?;
-                        server.watch_queue(&mut receiver).await?;
-                        Ok(())
+                        server.watch_queue(&mut receiver).await
                     }
                     SocketType::Zmq => {
                         let server = OutputServerOptions::<Publish>::new(&host, port).await?;
-                        server.watch_queue(&mut receiver).await?;
-                        Ok(())
+                        server.watch_queue(&mut receiver).await
                     }
                 }
-            }
-            .await;
+            };
+
+            let result: Option<Result<()>> = tokio::select! {
+                biased;
+                () = cancel.cancelled() => None,
+                r = work => Some(r),
+            };
 
             match result {
-                Ok(()) => info!("[SUPERVISOR][{label}] Task exited gracefully; restarting"),
-                Err(e) => error!("[SUPERVISOR][{label}] Task failed: {e}; restarting"),
+                None => {
+                    info!("[SUPERVISOR][{label}] Cancelled; exiting");
+                    break;
+                }
+                Some(Ok(())) => {
+                    info!("[SUPERVISOR][{label}] Task exited gracefully; restarting");
+                }
+                Some(Err(e)) => {
+                    error!("[SUPERVISOR][{label}] Task failed: {e}; restarting");
+                }
             }
 
             if started.elapsed() >= Duration::from_secs(60) {
@@ -160,10 +206,49 @@ fn spawn_output(proto: SocketType, host: String, port: u16, mut receiver: mpsc::
             }
 
             info!("[SUPERVISOR][{label}] Sleeping {backoff_secs}s before restart");
-            tokio::time::sleep(Duration::from_secs(backoff_secs)).await;
+            tokio::select! {
+                biased;
+                () = cancel.cancelled() => {
+                    info!("[SUPERVISOR][{label}] Cancelled during backoff; exiting");
+                    break;
+                }
+                () = tokio::time::sleep(Duration::from_secs(backoff_secs)) => {}
+            }
             backoff_secs = (backoff_secs.saturating_mul(2)).min(60);
         }
-    });
+    })
+}
+
+/// Wait for either SIGINT (Ctrl-C) or, on Unix, SIGTERM. Container
+/// orchestrators (docker stop, systemd) typically send SIGTERM, which the
+/// default `tokio::signal::ctrl_c()` alone does not catch.
+async fn shutdown_signal() {
+    let ctrl_c = async {
+        if let Err(e) = tokio::signal::ctrl_c().await {
+            error!("Failed to install Ctrl-C handler: {e}");
+        }
+    };
+
+    #[cfg(unix)]
+    let terminate = async {
+        match tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate()) {
+            Ok(mut sig) => {
+                sig.recv().await;
+            }
+            Err(e) => {
+                error!("Failed to install SIGTERM handler: {e}");
+                std::future::pending::<()>().await;
+            }
+        }
+    };
+
+    #[cfg(not(unix))]
+    let terminate = std::future::pending::<()>();
+
+    tokio::select! {
+        () = ctrl_c => info!("[SHUTDOWN] Received SIGINT"),
+        () = terminate => info!("[SHUTDOWN] Received SIGTERM"),
+    }
 }
 
 #[tokio::main]
@@ -194,20 +279,27 @@ async fn main() -> Result<()> {
     let print_interval = config.get_stat_interval();
     stats.run(print_interval);
 
+    // One CancellationToken governs the whole process. Input supervisors and
+    // the output supervisor each get a clone. On shutdown, main cancels the
+    // token and waits for supervisors in a specific order to drain the
+    // pipeline.
+    let cancel = CancellationToken::new();
+
     // Spawn the supervised input.
     info!("Creating input server");
     let input_proto = SocketType::try_from(config.get_source_protocol())
         .map_err(|e| anyhow::anyhow!("Error parsing source protocol: {e}"))?;
-    spawn_input(
+    let input_handle = spawn_input(
         input_proto,
         config.get_source_host().to_string(),
         config.get_source_port(),
         bridge_sender_master.clone(),
         stats_sender_master.clone(),
+        cancel.clone(),
     );
 
     // Spawn the supervised output, if configured.
-    if config.is_destination_set() {
+    let output_handle = if config.is_destination_set() {
         let rx = bridge_receiver.expect("bridge receiver should exist when destination is set");
         let host = config
             .get_destination_host()
@@ -224,17 +316,41 @@ async fn main() -> Result<()> {
             .map_err(|e| anyhow::anyhow!("Error parsing destination protocol: {e}"))?;
 
         info!("Creating output server");
-        spawn_output(output_proto, host, port, rx);
+        Some(spawn_output(output_proto, host, port, rx, cancel.clone()))
+    } else {
+        None
+    };
+
+    // Wait for a shutdown signal.
+    shutdown_signal().await;
+
+    info!("[SHUTDOWN] Cancelling supervisors");
+    cancel.cancel();
+
+    // Drain order:
+    //
+    //   1. Wait for the input supervisor to exit. Its inner task is aborted
+    //      via the cancel token, and its loop breaks before it can respawn.
+    //   2. Drop the master bridge Sender. Now no Sender for the bridge
+    //      channel exists; the output's recv() will return None once the
+    //      buffered messages are drained.
+    //   3. Wait for the output supervisor to drain and exit.
+    //   4. Drop the master stats Sender. The stats watcher's recv() will
+    //      return None and it exits cleanly.
+    if let Err(e) = input_handle.await {
+        error!("[SHUTDOWN] Input supervisor join error: {e}");
     }
 
-    // Keep master Senders alive for the lifetime of the process by holding
-    // them here. Without these bindings the compiler would drop them at the
-    // end of `main`'s setup and close the channels we just worked to keep
-    // open.
-    let _bridge_keepalive = bridge_sender_master;
-    let _stats_keepalive = stats_sender_master;
+    drop(bridge_sender_master);
 
-    loop {
-        tokio::time::sleep(Duration::from_secs(10)).await;
+    if let Some(handle) = output_handle
+        && let Err(e) = handle.await
+    {
+        error!("[SHUTDOWN] Output supervisor join error: {e}");
     }
+
+    drop(stats_sender_master);
+
+    info!("[SHUTDOWN] Clean exit");
+    Ok(())
 }

--- a/src/serverconfig.rs
+++ b/src/serverconfig.rs
@@ -15,36 +15,10 @@ pub enum SocketType {
     Zmq,
 }
 
-impl TryFrom<String> for SocketType {
-    type Error = Error;
-
-    fn try_from(s: String) -> Result<Self> {
-        match s.to_lowercase().as_str() {
-            "tcp" => Ok(Self::Tcp),
-            "udp" => Ok(Self::Udp),
-            "zmq" => Ok(Self::Zmq),
-            _ => Err(Error::msg(format!("Unknown Socket Type: {s}"))),
-        }
-    }
-}
-
 impl TryFrom<&str> for SocketType {
     type Error = Error;
 
     fn try_from(s: &str) -> Result<Self> {
-        match s.to_lowercase().as_str() {
-            "tcp" => Ok(Self::Tcp),
-            "udp" => Ok(Self::Udp),
-            "zmq" => Ok(Self::Zmq),
-            _ => Err(Error::msg(format!("Unknown Socket Type: {s}"))),
-        }
-    }
-}
-
-impl TryFrom<&String> for SocketType {
-    type Error = Error;
-
-    fn try_from(s: &String) -> Result<Self> {
         match s.to_lowercase().as_str() {
             "tcp" => Ok(Self::Tcp),
             "udp" => Ok(Self::Udp),

--- a/src/serverconfig.rs
+++ b/src/serverconfig.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 Fred Clausen
+// Copyright (c) 2024-2026 Fred Clausen
 //
 // Licensed under the MIT license: https://opensource.org/licenses/MIT
 // Permission is granted to use, copy, modify, and redistribute the work.
@@ -66,7 +66,6 @@ pub struct OutputServerOptions<T> {
     pub host: String,
     pub port: u16,
     pub socket: T,
-    pub receiver: Receiver<String>,
 }
 
 #[async_trait]
@@ -79,15 +78,15 @@ pub trait InputServer {
     ) -> Result<Self, Error>
     where
         Self: Sized;
-    async fn receive_message(self);
+    async fn receive_message(self) -> Result<(), Error>;
     fn format_name(&self) -> String;
 }
 
 #[async_trait]
 pub trait OutputServer {
-    async fn new(host: &str, port: u16, receiver: Receiver<String>) -> Result<Self, Error>
+    async fn new(host: &str, port: u16) -> Result<Self, Error>
     where
         Self: Sized;
-    async fn watch_queue(self);
+    async fn watch_queue(self, receiver: &mut Receiver<String>) -> Result<(), Error>;
     fn format_name(&self) -> String;
 }

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -77,12 +77,21 @@ pub async fn print_stats_to_console(
     total_since_last_context: Arc<AtomicU64>,
     print_interval: u64,
 ) {
+    // print interval is in minutes, so we need to convert it to seconds.
+    // saturating_mul guards against u64 overflow if the user passes a
+    // pathological value (a debug-mode panic / release-mode wrap).
+    let print_interval_in_seconds = print_interval.saturating_mul(60);
+
+    // tokio::time::interval gives drift-free ticks: each tick fires at a
+    // multiple of the period from the start instant, so time spent printing
+    // and resetting counters does not push successive intervals later. The
+    // first tick fires immediately, so skip it.
+    let mut ticker =
+        tokio::time::interval(tokio::time::Duration::from_secs(print_interval_in_seconds));
+    ticker.tick().await;
+
     loop {
-        // print interval is in minutes, so we need to convert it to seconds.
-        // saturating_mul guards against u64 overflow if the user passes a
-        // pathological value (a debug-mode panic / release-mode wrap).
-        let print_interval_in_seconds = print_interval.saturating_mul(60);
-        tokio::time::sleep(tokio::time::Duration::from_secs(print_interval_in_seconds)).await;
+        ticker.tick().await;
         let total_all_time = total_all_time_context.load(Ordering::Relaxed);
         // Atomically swap the per-interval counter to 0 so increments that
         // happen between the read and the reset are not lost.

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 Fred Clausen
+// Copyright (c) 2024-2026 Fred Clausen
 //
 // Licensed under the MIT license: https://opensource.org/licenses/MIT
 // Permission is granted to use, copy, modify, and redistribute the work.
@@ -47,17 +47,14 @@ impl Stats {
     }
 
     pub async fn watch_message_queue(&mut self) {
-        loop {
-            match self.receiver.recv().await {
-                Some(_) => {
-                    trace!("[STATS] Received message from queue");
-                    self.increment().await;
-                }
-                None => {
-                    error!("[STATS] Error receiving message from queue");
-                }
-            }
+        while self.receiver.recv().await.is_some() {
+            trace!("[STATS] Received message from queue");
+            self.increment().await;
         }
+        // All Senders have been dropped. This should not happen under normal
+        // operation because main retains a master Sender, but if it does we
+        // exit cleanly instead of spinning on the closed channel.
+        warn!("[STATS] Stats channel closed (all senders dropped); exiting stats watcher");
     }
 
     pub async fn increment(&mut self) {

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -50,10 +50,12 @@ impl Stats {
             trace!("[STATS] Received message from queue");
             self.increment();
         }
-        // All Senders have been dropped. This should not happen under normal
-        // operation because main retains a master Sender, but if it does we
-        // exit cleanly instead of spinning on the closed channel.
-        warn!("[STATS] Stats channel closed (all senders dropped); exiting stats watcher");
+        // All Senders have been dropped. Under normal operation main retains
+        // a master Sender, so this only happens during graceful shutdown
+        // (main drops its Sender after the output supervisor exits). Logged
+        // at debug! to avoid emitting a false-positive warning on every
+        // clean exit.
+        debug!("[STATS] Stats channel closed (all senders dropped); exiting stats watcher");
     }
 
     fn increment(&self) {

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -45,7 +45,7 @@ impl Stats {
         });
     }
 
-    pub async fn watch_message_queue(&mut self) {
+    async fn watch_message_queue(&mut self) {
         while self.receiver.recv().await.is_some() {
             trace!("[STATS] Received message from queue");
             self.increment();
@@ -56,7 +56,7 @@ impl Stats {
         warn!("[STATS] Stats channel closed (all senders dropped); exiting stats watcher");
     }
 
-    pub fn increment(&self) {
+    fn increment(&self) {
         self.total_all_time.fetch_add(1, Ordering::Relaxed);
         self.total_since_last.fetch_add(1, Ordering::Relaxed);
     }
@@ -72,7 +72,7 @@ impl Stats {
     }
 }
 
-pub async fn print_stats_to_console(
+async fn print_stats_to_console(
     total_all_time_context: Arc<AtomicU64>,
     total_since_last_context: Arc<AtomicU64>,
     print_interval: u64,

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -5,29 +5,28 @@
 // Full license information available in the project LICENSE file.
 
 use std::sync::Arc;
-use tokio::sync::Mutex;
+use std::sync::atomic::{AtomicU64, Ordering};
 use tokio::sync::mpsc::Receiver;
 // A struct to hold the stats
 
 pub struct Stats {
-    pub total_all_time: Arc<Mutex<u64>>,
-    pub total_since_last: Arc<Mutex<u64>>,
+    total_all_time: Arc<AtomicU64>,
+    total_since_last: Arc<AtomicU64>,
     receiver: Receiver<u8>,
 }
 
 impl Stats {
     #[must_use]
     pub fn new(receiver: Receiver<u8>) -> Self {
-        // wrap the stats in an Arc<Mutex<Stats>> to allow for multiple threads to access it
         Self {
-            total_all_time: Arc::new(Mutex::new(0)),
-            total_since_last: Arc::new(Mutex::new(0)),
+            total_all_time: Arc::new(AtomicU64::new(0)),
+            total_since_last: Arc::new(AtomicU64::new(0)),
             receiver,
         }
     }
 
     pub fn run(mut self, print_interval: u64) {
-        // clone the Arc<Mutex<Stats>> so we can pass it to the print_stats function
+        // clone the Arcs so we can pass them to the print_stats function
         let total_all_time_context = self.total_all_time.clone();
         let total_since_last_context = self.total_since_last.clone();
 
@@ -49,7 +48,7 @@ impl Stats {
     pub async fn watch_message_queue(&mut self) {
         while self.receiver.recv().await.is_some() {
             trace!("[STATS] Received message from queue");
-            self.increment().await;
+            self.increment();
         }
         // All Senders have been dropped. This should not happen under normal
         // operation because main retains a master Sender, but if it does we
@@ -57,31 +56,35 @@ impl Stats {
         warn!("[STATS] Stats channel closed (all senders dropped); exiting stats watcher");
     }
 
-    pub async fn increment(&mut self) {
-        *self.total_all_time.lock().await += 1;
-        *self.total_since_last.lock().await += 1;
+    pub fn increment(&self) {
+        self.total_all_time.fetch_add(1, Ordering::Relaxed);
+        self.total_since_last.fetch_add(1, Ordering::Relaxed);
     }
 
-    pub async fn get_total_all_time(&self) -> u64 {
-        *self.total_all_time.lock().await
+    #[must_use]
+    pub fn get_total_all_time(&self) -> u64 {
+        self.total_all_time.load(Ordering::Relaxed)
     }
 
-    pub async fn get_total_last_interval(&self) -> u64 {
-        *self.total_since_last.lock().await
+    #[must_use]
+    pub fn get_total_last_interval(&self) -> u64 {
+        self.total_since_last.load(Ordering::Relaxed)
     }
 }
 
 pub async fn print_stats_to_console(
-    total_all_time_context: Arc<Mutex<u64>>,
-    total_since_last_context: Arc<Mutex<u64>>,
+    total_all_time_context: Arc<AtomicU64>,
+    total_since_last_context: Arc<AtomicU64>,
     print_interval: u64,
 ) {
     loop {
         // print interval is in minutes, so we need to convert it to seconds
         let print_interval_in_seconds = print_interval * 60;
         tokio::time::sleep(tokio::time::Duration::from_secs(print_interval_in_seconds)).await;
-        let total_all_time = *total_all_time_context.lock().await;
-        let total_since_last = *total_since_last_context.lock().await;
+        let total_all_time = total_all_time_context.load(Ordering::Relaxed);
+        // Atomically swap the per-interval counter to 0 so increments that
+        // happen between the read and the reset are not lost.
+        let total_since_last = total_since_last_context.swap(0, Ordering::Relaxed);
 
         info!("[STATS] Total since container start: {total_all_time}");
         info!(
@@ -90,10 +93,5 @@ pub async fn print_stats_to_console(
             if print_interval > 1 { "s" } else { "" },
             total_since_last
         );
-
-        // set the total_last_interval to 0
-        *total_since_last_context.lock().await = 0;
-
-        // FIXME: Can we have a situation where the mutex is written to after we've read the value but before we've reset it?
     }
 }

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -60,16 +60,6 @@ impl Stats {
         self.total_all_time.fetch_add(1, Ordering::Relaxed);
         self.total_since_last.fetch_add(1, Ordering::Relaxed);
     }
-
-    #[must_use]
-    pub fn get_total_all_time(&self) -> u64 {
-        self.total_all_time.load(Ordering::Relaxed)
-    }
-
-    #[must_use]
-    pub fn get_total_last_interval(&self) -> u64 {
-        self.total_since_last.load(Ordering::Relaxed)
-    }
 }
 
 async fn print_stats_to_console(

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -78,8 +78,10 @@ pub async fn print_stats_to_console(
     print_interval: u64,
 ) {
     loop {
-        // print interval is in minutes, so we need to convert it to seconds
-        let print_interval_in_seconds = print_interval * 60;
+        // print interval is in minutes, so we need to convert it to seconds.
+        // saturating_mul guards against u64 overflow if the user passes a
+        // pathological value (a debug-mode panic / release-mode wrap).
+        let print_interval_in_seconds = print_interval.saturating_mul(60);
         tokio::time::sleep(tokio::time::Duration::from_secs(print_interval_in_seconds)).await;
         let total_all_time = total_all_time_context.load(Ordering::Relaxed);
         // Atomically swap the per-interval counter to 0 so increments that

--- a/src/tcp.rs
+++ b/src/tcp.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 Fred Clausen
+// Copyright (c) 2024-2026 Fred Clausen
 //
 // Licensed under the MIT license: https://opensource.org/licenses/MIT
 // Permission is granted to use, copy, modify, and redistribute the work.
@@ -16,7 +16,8 @@ use tokio::io::AsyncWriteExt;
 use tokio::io::BufWriter;
 use tokio::net::TcpStream;
 use tokio::net::lookup_host;
-use tokio::sync::mpsc::{Receiver, Sender};
+use tokio::sync::mpsc::Receiver;
+use tokio::sync::mpsc::Sender;
 use tokio_stream::StreamExt;
 use tokio_util::codec::{Framed, LinesCodec};
 
@@ -33,11 +34,12 @@ use crate::serverconfig::OutputServerOptions;
 /// session the cached `SocketAddr` will be stale. Pre-resolving is the
 /// "bare `SocketAddr`" path explicitly called out as acceptable in the
 /// crate's 0.7.1 migration notes.
+///
+/// Pass `(host, port)` as a tuple rather than formatting `"{host}:{port}"`
+/// so that bare IPv6 literals (`2001:db8::1`) don't need to be bracketed
+/// by the caller; the tuple form delegates parsing to tokio/std and
+/// handles DNS names, IPv4, and IPv6 uniformly.
 async fn resolve_host(host: &str, port: u16) -> Result<SocketAddr, Error> {
-    // Pass `(host, port)` as a tuple rather than formatting `"{host}:{port}"`
-    // so that bare IPv6 literals (`2001:db8::1`) don't need to be bracketed
-    // by the caller; the tuple form delegates parsing to tokio/std and
-    // handles DNS names, IPv4, and IPv6 uniformly.
     lookup_host((host, port))
         .await
         .with_context(|| format!("DNS lookup failed for {host}:{port}"))?
@@ -57,17 +59,12 @@ impl InputServer for InputServerOptions<StubbornIo<TcpStream>> {
             .await
             .with_context(|| format!("[TCP Input {host}:{port}] DNS resolution failed"))?;
 
-        let stream = match StubbornTcpStream::connect_with_options(
+        let stream = StubbornTcpStream::connect_with_options(
             addr,
             reconnect_options(&format!("{host}:{port}")),
         )
         .await
-        {
-            Ok(stream) => stream,
-            Err(e) => {
-                panic!("[TCP Input {host}:{port}] Error connecting {e}");
-            }
-        };
+        .map_err(|e| Error::msg(format!("[TCP Input {host}:{port}] Error connecting: {e}")))?;
 
         // return self now
         Ok(Self {
@@ -79,28 +76,37 @@ impl InputServer for InputServerOptions<StubbornIo<TcpStream>> {
         })
     }
 
-    async fn receive_message(self) {
+    async fn receive_message(self) -> Result<(), Error> {
         let name = self.format_name();
         let reader = tokio::io::BufReader::new(self.socket);
         let mut lines = Framed::new(reader, LinesCodec::new());
 
-        while let Some(Ok(line)) = lines.next().await {
+        while let Some(result) = lines.next().await {
+            let line = match result {
+                Ok(l) => l,
+                Err(e) => {
+                    warn!("{name}Decode error, skipping line: {e}");
+                    continue;
+                }
+            };
+
             debug!("{name}Received: {line}");
 
             if let Some(sender) = &self.sender {
-                match sender.send(line.clone()).await {
-                    Ok(()) => trace!("{name}Message sent to output channel"),
-                    Err(e) => panic!("{name}Error sending message to output channel: {e}"),
+                if let Err(e) = sender.send(line.clone()).await {
+                    return Err(Error::msg(format!("{name}Output channel closed: {e}")));
                 }
+                trace!("{name}Message sent to output channel");
             }
 
-            match self.stats.send(1).await {
-                Ok(()) => trace!("{name}Stats sent to channel"),
-                Err(e) => panic!("{name}Error sending stats to channel: {e}"),
+            if let Err(e) = self.stats.send(1).await {
+                return Err(Error::msg(format!("{name}Stats channel closed: {e}")));
             }
+            trace!("{name}Stats sent to channel");
         }
 
-        info!("{name}Connection closed, shutting down");
+        info!("{name}Connection closed by peer, shutting down");
+        Ok(())
     }
 
     fn format_name(&self) -> String {
@@ -110,36 +116,30 @@ impl InputServer for InputServerOptions<StubbornIo<TcpStream>> {
 
 #[async_trait]
 impl OutputServer for OutputServerOptions<StubbornIo<TcpStream>> {
-    async fn new(host: &str, port: u16, receiver: Receiver<String>) -> Result<Self, Error> {
+    async fn new(host: &str, port: u16) -> Result<Self, Error> {
         let addr = resolve_host(host, port)
             .await
             .with_context(|| format!("[TCP Output {host}:{port}] DNS resolution failed"))?;
 
-        let stream: StubbornIo<TcpStream> = match StubbornTcpStream::connect_with_options(
+        let stream: StubbornIo<TcpStream> = StubbornTcpStream::connect_with_options(
             addr,
             reconnect_options(&format!("{host}:{port}")),
         )
         .await
-        {
-            Ok(stream) => stream,
-            Err(e) => {
-                panic!("[TCP Output {host}:{port}] Error connecting {e}");
-            }
-        };
+        .map_err(|e| Error::msg(format!("[TCP Output {host}:{port}] Error connecting: {e}")))?;
 
         // return self now
         Ok(Self {
             host: host.to_string(),
             port,
             socket: stream,
-            receiver,
         })
     }
 
-    async fn watch_queue(mut self) {
+    async fn watch_queue(self, receiver: &mut Receiver<String>) -> Result<(), Error> {
         let name = self.format_name();
         let mut writer: BufWriter<StubbornIo<TcpStream>> = BufWriter::new(self.socket);
-        while let Some(line) = self.receiver.recv().await {
+        while let Some(line) = receiver.recv().await {
             debug!("{name}Received: {line}");
 
             // verify we have a newline
@@ -149,22 +149,23 @@ impl OutputServer for OutputServerOptions<StubbornIo<TcpStream>> {
                 format!("{line}\n")
             };
 
-            match writer.write(line.as_bytes()).await {
-                Ok(_) => {
-                    debug!("{name}Message sent to consumer");
-
-                    match writer.flush().await {
-                        Ok(()) => trace!("{name}Flushed message to consumer"),
-                        Err(e) => {
-                            panic!("{name}Error flushing message to consumer: {e}")
-                        }
-                    }
-                }
-                Err(e) => panic!("{name}Error sending message to consumer: {e}"),
+            if let Err(e) = writer.write(line.as_bytes()).await {
+                return Err(Error::msg(format!(
+                    "{name}Error sending message to consumer: {e}"
+                )));
             }
+            debug!("{name}Message sent to consumer");
+
+            if let Err(e) = writer.flush().await {
+                return Err(Error::msg(format!(
+                    "{name}Error flushing message to consumer: {e}"
+                )));
+            }
+            trace!("{name}Flushed message to consumer");
         }
 
         info!("{name}Queue is empty, shutting down");
+        Err(Error::msg(format!("{name}Input channel closed")))
     }
 
     fn format_name(&self) -> String {

--- a/src/tcp.rs
+++ b/src/tcp.rs
@@ -149,7 +149,7 @@ impl OutputServer for OutputServerOptions<StubbornIo<TcpStream>> {
                 format!("{line}\n")
             };
 
-            if let Err(e) = writer.write(line.as_bytes()).await {
+            if let Err(e) = writer.write_all(line.as_bytes()).await {
                 return Err(Error::msg(format!(
                     "{name}Error sending message to consumer: {e}"
                 )));

--- a/src/tcp.rs
+++ b/src/tcp.rs
@@ -164,8 +164,13 @@ impl OutputServer for OutputServerOptions<StubbornIo<TcpStream>> {
             trace!("{name}Flushed message to consumer");
         }
 
-        info!("{name}Queue is empty, shutting down");
-        Err(Error::msg(format!("{name}Input channel closed")))
+        // recv() returning None means all bridge Senders have been dropped,
+        // which happens only during graceful shutdown (main drops the master
+        // Sender after the input supervisor exits). Return Ok(()) so the
+        // output supervisor treats this as a terminal, clean exit rather than
+        // a failure to restart/log at error level.
+        info!("{name}Input channel closed (shutdown); exiting");
+        Ok(())
     }
 
     fn format_name(&self) -> String {

--- a/src/udp.rs
+++ b/src/udp.rs
@@ -108,7 +108,10 @@ impl OutputServer for OutputServerOptions<UdpSocket> {
         // fail fast (and let the supervisor back off + retry) rather than
         // discovering it on the first datagram. The resolved address is
         // recomputed once in watch_queue and reused for every send_to.
-        resolve_first(format!("{host}:{port}"))
+        // Pass `(host, port)` as a tuple rather than formatting
+        // `"{host}:{port}"` so bare IPv6 literals (`2001:db8::1`) don't need
+        // to be bracketed by the caller.
+        resolve_first((host, port))
             .await
             .map_err(|e| Error::msg(format!("[UDP Output {host}:{port}] Cannot resolve: {e}")))?;
         Ok(Self {
@@ -123,8 +126,9 @@ impl OutputServer for OutputServerOptions<UdpSocket> {
         // host:port string to send_to on every datagram, which forced DNS
         // resolution per call. Resolving once at task start eliminates that
         // overhead; the supervisor will rebuild this task (and re-resolve)
-        // on any send failure or restart.
-        let dest = resolve_first(format!("{}:{}", self.host, self.port))
+        // on any send failure or restart. The tuple form supports bare IPv6
+        // literals without requiring the caller to bracket them.
+        let dest = resolve_first((self.host.as_str(), self.port))
             .await
             .map_err(|e| {
                 Error::msg(format!(

--- a/src/udp.rs
+++ b/src/udp.rs
@@ -67,12 +67,12 @@ impl InputServer for InputServerOptions<UdpSocket> {
                     trace!("{}Stats sent to stats channel", self.format_name());
                 }
                 Err(e) => {
-                    // Bind/socket-level errors are fatal for this task; let supervisor rebind.
-                    return Err(Error::msg(format!(
-                        "{}Socket recv error: {:?}",
-                        self.format_name(),
-                        e
-                    )));
+                    // recv_from can surface transient kernel errors (e.g.
+                    // ICMP-driven ECONNREFUSED from a prior send_to, EINTR)
+                    // that don't warrant tearing down the bound socket. Log
+                    // and keep reading; the supervisor would otherwise rebind
+                    // for no reason and could even race with EADDRINUSE.
+                    error!("{}recv_from error: {:?}", self.format_name(), e);
                 }
             }
         }

--- a/src/udp.rs
+++ b/src/udp.rs
@@ -43,7 +43,23 @@ impl InputServer for InputServerOptions<UdpSocket> {
                         continue;
                     }
 
-                    let composed_message = String::from_utf8_lossy(&buf[..size]);
+                    // ACARS payloads are 7-bit ASCII in practice, but warn
+                    // loudly if non-UTF-8 bytes arrive so silent corruption
+                    // is visible. Fall back to lossy conversion so the
+                    // bridge still forwards something rather than dropping
+                    // the message entirely.
+                    let composed_message = match std::str::from_utf8(&buf[..size]) {
+                        Ok(s) => std::borrow::Cow::Borrowed(s),
+                        Err(e) => {
+                            warn!(
+                                "{}Non-UTF-8 datagram ({} bytes, error at byte {}); using lossy conversion",
+                                self.format_name(),
+                                size,
+                                e.valid_up_to()
+                            );
+                            String::from_utf8_lossy(&buf[..size])
+                        }
+                    };
 
                     debug!("{}Received: {}", self.format_name(), composed_message);
 

--- a/src/udp.rs
+++ b/src/udp.rs
@@ -96,7 +96,7 @@ impl InputServer for InputServerOptions<UdpSocket> {
     }
 
     fn format_name(&self) -> String {
-        format!("[UDP Input {}] ", self.port)
+        format!("[UDP Input {}:{}] ", self.host, self.port)
     }
 }
 

--- a/src/udp.rs
+++ b/src/udp.rs
@@ -1,6 +1,6 @@
 use crate::serverconfig::InputServer;
 use crate::serverconfig::InputServerOptions;
-// Copyright (c) 2024 Fred Clausen
+// Copyright (c) 2024-2026 Fred Clausen
 //
 // Licensed under the MIT license: https://opensource.org/licenses/MIT
 // Permission is granted to use, copy, modify, and redistribute the work.
@@ -32,7 +32,7 @@ impl InputServer for InputServerOptions<UdpSocket> {
         })
     }
 
-    async fn receive_message(self) {
+    async fn receive_message(self) -> Result<(), Error> {
         let mut buf = [0; 8192];
         loop {
             match self.socket.recv_from(&mut buf).await {
@@ -47,28 +47,33 @@ impl InputServer for InputServerOptions<UdpSocket> {
                     debug!("{}Received: {}", self.format_name(), composed_message);
 
                     if let Some(sender) = &self.sender {
-                        match sender.send(composed_message.to_string()).await {
-                            Ok(()) => {
-                                trace!("{}Message sent to sender channel", self.format_name());
-                            }
-                            Err(e) => panic!(
-                                "{}Error sending message to sender channel: {}",
+                        if let Err(e) = sender.send(composed_message.to_string()).await {
+                            return Err(Error::msg(format!(
+                                "{}Output channel closed: {}",
                                 self.format_name(),
                                 e
-                            ),
+                            )));
                         }
+                        trace!("{}Message sent to sender channel", self.format_name());
                     }
 
-                    match self.stats.send(1).await {
-                        Ok(()) => trace!("{}Stats sent to stats channel", self.format_name()),
-                        Err(e) => panic!(
-                            "{}Error sending to stats channel: {}",
+                    if let Err(e) = self.stats.send(1).await {
+                        return Err(Error::msg(format!(
+                            "{}Stats channel closed: {}",
                             self.format_name(),
                             e
-                        ),
+                        )));
                     }
+                    trace!("{}Stats sent to stats channel", self.format_name());
                 }
-                Err(e) => error!("{}Error: {:?}", self.format_name(), e),
+                Err(e) => {
+                    // Bind/socket-level errors are fatal for this task; let supervisor rebind.
+                    return Err(Error::msg(format!(
+                        "{}Socket recv error: {:?}",
+                        self.format_name(),
+                        e
+                    )));
+                }
             }
         }
     }
@@ -80,21 +85,20 @@ impl InputServer for InputServerOptions<UdpSocket> {
 
 #[async_trait]
 impl OutputServer for OutputServerOptions<UdpSocket> {
-    async fn new(host: &str, port: u16, receiver: Receiver<String>) -> Result<Self, Error> {
+    async fn new(host: &str, port: u16) -> Result<Self, Error> {
         let socket = UdpSocket::bind("0.0.0.0:0".to_string()).await?;
         Ok(Self {
             host: host.to_string(),
             port,
             socket,
-            receiver,
         })
     }
 
-    async fn watch_queue(mut self) {
+    async fn watch_queue(self, receiver: &mut Receiver<String>) -> Result<(), Error> {
         let max_size = 8192;
 
         loop {
-            match self.receiver.recv().await {
+            match receiver.recv().await {
                 Some(message) => {
                     debug!("{}Received: {}", self.format_name(), message);
 
@@ -121,22 +125,22 @@ impl OutputServer for OutputServerOptions<UdpSocket> {
                                 offset = end;
                             }
                             Err(e) => {
-                                // Other sender types panic at this point, but UDP is a best effort protocol, so we just log the error and continue
-
+                                // UDP is a best effort protocol; log and drop the rest of this datagram.
                                 error!(
                                     "{}Error sending message to consumer: {}",
                                     self.format_name(),
                                     e
                                 );
+                                break;
                             }
                         }
                     }
                 }
                 None => {
-                    panic!(
-                        "{}Error receiving message from sender input channel",
+                    return Err(Error::msg(format!(
+                        "{}Input channel closed",
                         self.format_name()
-                    );
+                    )));
                 }
             }
         }

--- a/src/udp.rs
+++ b/src/udp.rs
@@ -136,62 +136,62 @@ impl OutputServer for OutputServerOptions<UdpSocket> {
         debug!("{}Resolved destination to {}", self.format_name(), dest);
 
         loop {
-            match receiver.recv().await {
-                Some(message) => {
-                    debug!("{}Received: {}", self.format_name(), message);
+            let Some(message) = receiver.recv().await else {
+                // All bridge Senders have been dropped; this happens only
+                // during graceful shutdown. Return Ok(()) so the output
+                // supervisor treats it as a terminal, clean exit.
+                info!(
+                    "{}Input channel closed (shutdown); exiting",
+                    self.format_name()
+                );
+                return Ok(());
+            };
+            debug!("{}Received: {}", self.format_name(), message);
 
-                    // verify we have a newline
-                    let message = if message.ends_with('\n') {
-                        message
-                    } else {
-                        format!("{message}\n")
-                    };
+            // verify we have a newline
+            let message = if message.ends_with('\n') {
+                message
+            } else {
+                format!("{message}\n")
+            };
 
-                    // Send the entire message as a single UDP datagram. The
-                    // kernel handles IP fragmentation transparently for
-                    // messages larger than the path MTU; the receiver's
-                    // kernel reassembles before delivery. The previous
-                    // application-level chunking produced multiple
-                    // independent datagrams that the receiver had no way to
-                    // recombine, silently corrupting any message > 8192
-                    // bytes.
-                    //
-                    // The hard ceiling here is the UDP payload max
-                    // (~65507 bytes); messages larger than that produce
-                    // EMSGSIZE, which we log and drop.
-                    let bytes = message.as_bytes();
-                    match self.socket.send_to(bytes, &dest).await {
-                        Ok(n) if n < bytes.len() => {
-                            // Per POSIX, a UDP send_to either transmits the
-                            // entire datagram or fails. A short return would
-                            // indicate a kernel anomaly worth flagging.
-                            warn!(
-                                "{}Short UDP send: {} of {} bytes",
-                                self.format_name(),
-                                n,
-                                bytes.len()
-                            );
-                        }
-                        Ok(_) => trace!("{}Message sent to consumer", self.format_name()),
-                        Err(e) => {
-                            // UDP is best-effort; log and continue. Common
-                            // causes: EMSGSIZE (oversized message),
-                            // ENETUNREACH, ICMP-driven errors from a prior
-                            // datagram.
-                            error!(
-                                "{}Error sending message ({} bytes) to consumer: {}",
-                                self.format_name(),
-                                bytes.len(),
-                                e
-                            );
-                        }
-                    }
+            // Send the entire message as a single UDP datagram. The
+            // kernel handles IP fragmentation transparently for
+            // messages larger than the path MTU; the receiver's
+            // kernel reassembles before delivery. The previous
+            // application-level chunking produced multiple
+            // independent datagrams that the receiver had no way to
+            // recombine, silently corrupting any message > 8192
+            // bytes.
+            //
+            // The hard ceiling here is the UDP payload max
+            // (~65507 bytes); messages larger than that produce
+            // EMSGSIZE, which we log and drop.
+            let bytes = message.as_bytes();
+            match self.socket.send_to(bytes, &dest).await {
+                Ok(n) if n < bytes.len() => {
+                    // Per POSIX, a UDP send_to either transmits the
+                    // entire datagram or fails. A short return would
+                    // indicate a kernel anomaly worth flagging.
+                    warn!(
+                        "{}Short UDP send: {} of {} bytes",
+                        self.format_name(),
+                        n,
+                        bytes.len()
+                    );
                 }
-                None => {
-                    return Err(Error::msg(format!(
-                        "{}Input channel closed",
-                        self.format_name()
-                    )));
+                Ok(_) => trace!("{}Message sent to consumer", self.format_name()),
+                Err(e) => {
+                    // UDP is best-effort; log and continue. Common
+                    // causes: EMSGSIZE (oversized message),
+                    // ENETUNREACH, ICMP-driven errors from a prior
+                    // datagram.
+                    error!(
+                        "{}Error sending message ({} bytes) to consumer: {}",
+                        self.format_name(),
+                        bytes.len(),
+                        e
+                    );
                 }
             }
         }

--- a/src/udp.rs
+++ b/src/udp.rs
@@ -95,44 +95,56 @@ impl OutputServer for OutputServerOptions<UdpSocket> {
     }
 
     async fn watch_queue(self, receiver: &mut Receiver<String>) -> Result<(), Error> {
-        let max_size = 8192;
-
+        let dest = format!("{}:{}", self.host, self.port);
         loop {
             match receiver.recv().await {
                 Some(message) => {
                     debug!("{}Received: {}", self.format_name(), message);
 
-                    // convert string to bytes
                     // verify we have a newline
                     let message = if message.ends_with('\n') {
                         message
                     } else {
                         format!("{message}\n")
                     };
-                    let bytes = message.as_bytes();
-                    // send bytes to destination. If the message is larger than the max size, send up to max size and keep sending until the entire message is sent.
-                    let mut offset = 0;
-                    while offset < bytes.len() {
-                        let end = std::cmp::min(offset + max_size, bytes.len());
 
-                        match self
-                            .socket
-                            .send_to(&bytes[offset..end], format!("{}:{}", self.host, self.port))
-                            .await
-                        {
-                            Ok(_) => {
-                                trace!("{}Message sent to consumer", self.format_name(),);
-                                offset = end;
-                            }
-                            Err(e) => {
-                                // UDP is a best effort protocol; log and drop the rest of this datagram.
-                                error!(
-                                    "{}Error sending message to consumer: {}",
-                                    self.format_name(),
-                                    e
-                                );
-                                break;
-                            }
+                    // Send the entire message as a single UDP datagram. The
+                    // kernel handles IP fragmentation transparently for
+                    // messages larger than the path MTU; the receiver's
+                    // kernel reassembles before delivery. The previous
+                    // application-level chunking produced multiple
+                    // independent datagrams that the receiver had no way to
+                    // recombine, silently corrupting any message > 8192
+                    // bytes.
+                    //
+                    // The hard ceiling here is the UDP payload max
+                    // (~65507 bytes); messages larger than that produce
+                    // EMSGSIZE, which we log and drop.
+                    let bytes = message.as_bytes();
+                    match self.socket.send_to(bytes, &dest).await {
+                        Ok(n) if n < bytes.len() => {
+                            // Per POSIX, a UDP send_to either transmits the
+                            // entire datagram or fails. A short return would
+                            // indicate a kernel anomaly worth flagging.
+                            warn!(
+                                "{}Short UDP send: {} of {} bytes",
+                                self.format_name(),
+                                n,
+                                bytes.len()
+                            );
+                        }
+                        Ok(_) => trace!("{}Message sent to consumer", self.format_name()),
+                        Err(e) => {
+                            // UDP is best-effort; log and continue. Common
+                            // causes: EMSGSIZE (oversized message),
+                            // ENETUNREACH, ICMP-driven errors from a prior
+                            // datagram.
+                            error!(
+                                "{}Error sending message ({} bytes) to consumer: {}",
+                                self.format_name(),
+                                bytes.len(),
+                                e
+                            );
                         }
                     }
                 }

--- a/src/udp.rs
+++ b/src/udp.rs
@@ -1,5 +1,3 @@
-use crate::serverconfig::InputServer;
-use crate::serverconfig::InputServerOptions;
 // Copyright (c) 2024-2026 Fred Clausen
 //
 // Licensed under the MIT license: https://opensource.org/licenses/MIT
@@ -12,6 +10,8 @@ use std::net::SocketAddr;
 use tokio::net::{ToSocketAddrs, UdpSocket};
 use tokio::sync::mpsc::{Receiver, Sender};
 
+use crate::serverconfig::InputServer;
+use crate::serverconfig::InputServerOptions;
 use crate::serverconfig::OutputServer;
 use crate::serverconfig::OutputServerOptions;
 

--- a/src/udp.rs
+++ b/src/udp.rs
@@ -8,7 +8,8 @@ use crate::serverconfig::InputServerOptions;
 
 use anyhow::{Error, Result};
 use async_trait::async_trait;
-use tokio::net::UdpSocket;
+use std::net::SocketAddr;
+use tokio::net::{ToSocketAddrs, UdpSocket};
 use tokio::sync::mpsc::{Receiver, Sender};
 
 use crate::serverconfig::OutputServer;
@@ -86,7 +87,14 @@ impl InputServer for InputServerOptions<UdpSocket> {
 #[async_trait]
 impl OutputServer for OutputServerOptions<UdpSocket> {
     async fn new(host: &str, port: u16) -> Result<Self, Error> {
-        let socket = UdpSocket::bind("0.0.0.0:0".to_string()).await?;
+        let socket = UdpSocket::bind("0.0.0.0:0").await?;
+        // Validate that the destination resolves at construction time so we
+        // fail fast (and let the supervisor back off + retry) rather than
+        // discovering it on the first datagram. The resolved address is
+        // recomputed once in watch_queue and reused for every send_to.
+        resolve_first(format!("{host}:{port}"))
+            .await
+            .map_err(|e| Error::msg(format!("[UDP Output {host}:{port}] Cannot resolve: {e}")))?;
         Ok(Self {
             host: host.to_string(),
             port,
@@ -95,7 +103,22 @@ impl OutputServer for OutputServerOptions<UdpSocket> {
     }
 
     async fn watch_queue(self, receiver: &mut Receiver<String>) -> Result<(), Error> {
-        let dest = format!("{}:{}", self.host, self.port);
+        // Resolve the destination once. The previous implementation passed a
+        // host:port string to send_to on every datagram, which forced DNS
+        // resolution per call. Resolving once at task start eliminates that
+        // overhead; the supervisor will rebuild this task (and re-resolve)
+        // on any send failure or restart.
+        let dest = resolve_first(format!("{}:{}", self.host, self.port))
+            .await
+            .map_err(|e| {
+                Error::msg(format!(
+                    "{}Cannot resolve destination: {}",
+                    self.format_name(),
+                    e
+                ))
+            })?;
+        debug!("{}Resolved destination to {}", self.format_name(), dest);
+
         loop {
             match receiver.recv().await {
                 Some(message) => {
@@ -161,4 +184,14 @@ impl OutputServer for OutputServerOptions<UdpSocket> {
     fn format_name(&self) -> String {
         format!("[UDP Output {}:{}] ", self.host, self.port)
     }
+}
+
+/// Resolve the given host:port to a single `SocketAddr`, taking the first entry
+/// from the iterator. Returns an error if resolution succeeds but yields no
+/// addresses.
+async fn resolve_first<A: ToSocketAddrs>(addr: A) -> Result<SocketAddr, Error> {
+    tokio::net::lookup_host(addr)
+        .await?
+        .next()
+        .ok_or_else(|| Error::msg("DNS resolution returned no addresses"))
 }

--- a/src/zmq.rs
+++ b/src/zmq.rs
@@ -85,11 +85,14 @@ impl InputServer for InputServerOptions<Subscribe> {
             trace!("{}Stats sent to channel", self.format_name());
         }
 
-        info!(
-            "{}ZMQ subscribe stream ended, shutting down",
+        // A tmq Subscribe stream should not normally end on its own. If we
+        // get here, something unexpected happened (context dropped, etc.).
+        // Surface as Err so the supervisor logs at error! level rather than
+        // info! and treats it as an abnormal restart.
+        Err(Error::msg(format!(
+            "{}ZMQ subscribe stream ended unexpectedly",
             self.format_name()
-        );
-        Ok(())
+        )))
     }
 
     fn format_name(&self) -> String {

--- a/src/zmq.rs
+++ b/src/zmq.rs
@@ -52,10 +52,25 @@ impl InputServer for InputServerOptions<Subscribe> {
                 }
             };
 
+            // Join all frames with spaces. ACARS payloads are 7-bit ASCII in
+            // practice, but warn loudly if a frame contains non-UTF-8 bytes
+            // so silent corruption is visible. Fall back to lossy conversion
+            // so the bridge still forwards something.
             let composed_message = message
                 .iter()
-                .map(|item| item.as_str().unwrap_or("invalid text"))
-                .collect::<Vec<&str>>()
+                .map(|item| match std::str::from_utf8(item) {
+                    Ok(s) => std::borrow::Cow::Borrowed(s),
+                    Err(e) => {
+                        warn!(
+                            "{}Non-UTF-8 frame ({} bytes, error at byte {}); using lossy conversion",
+                            self.format_name(),
+                            item.len(),
+                            e.valid_up_to()
+                        );
+                        String::from_utf8_lossy(item)
+                    }
+                })
+                .collect::<Vec<_>>()
                 .join(" ");
 
             debug!("{}Received: {}", self.format_name(), composed_message);

--- a/src/zmq.rs
+++ b/src/zmq.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 Fred Clausen
+// Copyright (c) 2024-2026 Fred Clausen
 //
 // Licensed under the MIT license: https://opensource.org/licenses/MIT
 // Permission is granted to use, copy, modify, and redistribute the work.
@@ -42,7 +42,7 @@ impl InputServer for InputServerOptions<Subscribe> {
         })
     }
 
-    async fn receive_message(mut self) {
+    async fn receive_message(mut self) -> Result<(), Error> {
         while let Some(msg) = self.socket.next().await {
             let message = match msg {
                 Ok(message) => message,
@@ -65,25 +65,31 @@ impl InputServer for InputServerOptions<Subscribe> {
                 .unwrap_or(&composed_message);
 
             if let Some(sender) = &self.sender {
-                match sender.send(stripped.to_string()).await {
-                    Ok(()) => trace!("{}Message sent to sender channel", self.format_name()),
-                    Err(e) => panic!(
-                        "{}Error sending message to sender channel: {}",
+                if let Err(e) = sender.send(stripped.to_string()).await {
+                    return Err(Error::msg(format!(
+                        "{}Output channel closed: {}",
                         self.format_name(),
                         e
-                    ),
+                    )));
                 }
+                trace!("{}Message sent to sender channel", self.format_name());
             }
 
-            match self.stats.send(1).await {
-                Ok(()) => trace!("{}Stats sent to channel", self.format_name()),
-                Err(e) => panic!(
-                    "{}Error sending stats to channel: {}",
+            if let Err(e) = self.stats.send(1).await {
+                return Err(Error::msg(format!(
+                    "{}Stats channel closed: {}",
                     self.format_name(),
                     e
-                ),
+                )));
             }
+            trace!("{}Stats sent to channel", self.format_name());
         }
+
+        info!(
+            "{}ZMQ subscribe stream ended, shutting down",
+            self.format_name()
+        );
+        Ok(())
     }
 
     fn format_name(&self) -> String {
@@ -93,7 +99,7 @@ impl InputServer for InputServerOptions<Subscribe> {
 
 #[async_trait]
 impl OutputServer for OutputServerOptions<Publish> {
-    async fn new(host: &str, port: u16, receiver: Receiver<String>) -> Result<Self, Error> {
+    async fn new(host: &str, port: u16) -> Result<Self, Error> {
         let address = format!("tcp://{host}:{port}");
         let socket = publish(&Context::new()).connect(&address)?;
 
@@ -101,25 +107,29 @@ impl OutputServer for OutputServerOptions<Publish> {
             host: host.to_string(),
             port,
             socket,
-            receiver,
         })
     }
 
-    async fn watch_queue(mut self) {
-        while let Some(message) = self.receiver.recv().await {
+    async fn watch_queue(mut self, receiver: &mut Receiver<String>) -> Result<(), Error> {
+        while let Some(message) = receiver.recv().await {
             debug!("{}Received: {}", self.format_name(), message);
 
             let message_zmq = vec![&message];
 
-            match self.socket.send(message_zmq).await {
-                Ok(()) => trace!("{}Message sent to consumer", self.format_name()),
-                Err(e) => panic!(
+            if let Err(e) = self.socket.send(message_zmq).await {
+                return Err(Error::msg(format!(
                     "{}Error sending message to consumer: {}",
                     self.format_name(),
                     e
-                ),
+                )));
             }
+            trace!("{}Message sent to consumer", self.format_name());
         }
+
+        Err(Error::msg(format!(
+            "{}Input channel closed",
+            self.format_name()
+        )))
     }
 
     fn format_name(&self) -> String {

--- a/src/zmq.rs
+++ b/src/zmq.rs
@@ -155,10 +155,14 @@ impl OutputServer for OutputServerOptions<Publish> {
             trace!("{}Message sent to consumer", self.format_name());
         }
 
-        Err(Error::msg(format!(
-            "{}Input channel closed",
+        // All bridge Senders have been dropped; this happens only during
+        // graceful shutdown. Return Ok(()) so the output supervisor treats it
+        // as a terminal, clean exit rather than a failure to restart.
+        info!(
+            "{}Input channel closed (shutdown); exiting",
             self.format_name()
-        )))
+        );
+        Ok(())
     }
 
     fn format_name(&self) -> String {

--- a/src/zmq.rs
+++ b/src/zmq.rs
@@ -8,6 +8,7 @@ use anyhow::{Error, Result};
 use async_trait::async_trait;
 use futures::SinkExt;
 use futures::StreamExt;
+use std::sync::OnceLock;
 use tmq::Context;
 use tmq::publish;
 use tmq::publish::Publish;
@@ -20,6 +21,18 @@ use crate::serverconfig::InputServerOptions;
 use crate::serverconfig::OutputServer;
 use crate::serverconfig::OutputServerOptions;
 
+/// Return the process-wide `ZeroMQ` `Context`, creating it on first use.
+///
+/// `ZeroMQ` contexts spin up their own I/O threads and own all socket file
+/// descriptors for the lifetime of the context. They are designed to be
+/// long-lived singletons; creating one per socket (which is what happened
+/// before this lookup, on every supervisor restart) leaks I/O threads and
+/// FDs over time when restarts happen frequently.
+fn zmq_context() -> &'static Context {
+    static CONTEXT: OnceLock<Context> = OnceLock::new();
+    CONTEXT.get_or_init(Context::new)
+}
+
 #[async_trait]
 impl InputServer for InputServerOptions<Subscribe> {
     async fn new(
@@ -29,9 +42,7 @@ impl InputServer for InputServerOptions<Subscribe> {
         stats: Sender<u8>,
     ) -> Result<Self, Error> {
         let address = format!("tcp://{host}:{port}");
-        let socket = subscribe(&Context::new())
-            .connect(&address)?
-            .subscribe(b"")?;
+        let socket = subscribe(zmq_context()).connect(&address)?.subscribe(b"")?;
 
         Ok(Self {
             host: host.to_string(),
@@ -119,7 +130,7 @@ impl InputServer for InputServerOptions<Subscribe> {
 impl OutputServer for OutputServerOptions<Publish> {
     async fn new(host: &str, port: u16) -> Result<Self, Error> {
         let address = format!("tcp://{host}:{port}");
-        let socket = publish(&Context::new()).connect(&address)?;
+        let socket = publish(zmq_context()).connect(&address)?;
 
         Ok(Self {
             host: host.to_string(),


### PR DESCRIPTION
## Summary

Originated from a stats-channel log-spam bug: when the input task died, its `Sender<u8>` clone was dropped, closing the stats channel and causing `recv()` to spin returning `None`. Fixing it surfaced a wider audit; this branch works through that audit as atomic commits.

Bumps to **v0.3.0**.

## Highlights

- **Supervision model rebuilt.** `main` retains master `Sender` clones; per-task supervisors restart only the failed side with exponential backoff (1s → 60s, reset after 60s stable). No more cascading shutdowns when one socket flaps.
- **Graceful shutdown.** `SIGINT`/`SIGTERM` trigger a coordinated drain: cancel → join input → drop bridge master `Sender` → join output → drop stats master `Sender` → exit. No timeout; second signal aborts.
- **Stats correctness.** `Arc<AtomicU64>` counters with `swap(0, Relaxed)` close the reset race. Stat ticks use `tokio::time::interval` to avoid drift.
- **ZMQ.** Single process-wide `OnceLock<tmq::Context>` instead of per-task contexts.
- **UDP.** Removed application-level chunking (kernel fragments; oversize surfaces as `EMSGSIZE`); pre-resolve destination once; log-and-continue on transient `recv_from` errors.
- **TCP.** `write_all` to guarantee full writes; graceful peer-close returns `Ok(())`.
- **Config.** New `--channel-capacity` / `AB_CHANNEL_CAPACITY` (default 1024). `--stat-interval` rejects `0` at parse time.
- **Lints.** Strict clippy (`pedantic + nursery + style + correctness + all`) moved from `main.rs` into `Cargo.toml [lints.clippy]`.
- **Release profile.** `lto = "thin"`, `codegen-units = 1`, `strip = "symbols"`, `panic = "abort"`.
- **Deps refreshed.** `tokio` 1.52.3, `log` 0.4.30, `futures` 0.3.32, `anyhow` 1.0.102, plus 15 transitive updates.
- **Docs.** README now covers env vars, `--channel-capacity`, supervision, and shutdown behavior. Also fixes a stale `--stats-interval` reference (real flag is `--stat-interval`).

## Test plan

- Release build under SIGTERM exits cleanly with ordered supervisor shutdown (verified via `timeout --signal=TERM 3 ./target/release/acars-bridge ...`).
- All pre-commit hooks pass on every commit (clippy, rustfmt, prettier, markdownlint, codespell, etc.).
- Original bug scenario (input death) no longer spams the log; supervisor restarts the input side and stats channel stays open.

## Commit log

26 atomic commits, each tagged with its audit ID (H1–H6, M1–M9, L1–L6, A1–A4). See `git log main..harden-supervision`.