### PR TITLE
migrate to sdre-stubborn-io 0.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -640,9 +640,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
 
 [[package]]
 name = "memchr"
@@ -882,9 +882,9 @@ dependencies = [
 
 [[package]]
 name = "sdre-stubborn-io"
-version = "0.6.19"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38cdbcb397b780d75405b636b3d86f89faed85af30adc4039e51cb75101521d5"
+checksum = "e890316930e6a6dc0d3cbaf1cd4988cd3037b5a853d996798bd6c343834c8a60"
 dependencies = [
  "log",
  "rand",
@@ -1057,9 +1057,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.52.2"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "110a78583f19d5cdb2c5ccf321d1290344e71313c6c37d43520d386027d18386"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,15 +7,15 @@ rust-version = "1.91"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-log = "0.4.29"
-tokio = { version = "1.52.2", features = ["full", "tracing"] }
-tokio-util = { version = "0.7.18", features = ["full"] }
-tokio-stream = "0.1.18"
-sdre-rust-logging = "0.3.27"
-clap = { version = "4.6.1", features = ["derive", "env"] }
-sdre-stubborn-io = "0.6.19"
-async-trait = "0.1.89"
-zmq = "0.10.0"
-tmq = "0.5.0"
-futures = "0.3.31"
 anyhow = "1.0.100"
+async-trait = "0.1.89"
+clap = { version = "4.6.1", features = ["derive", "env"] }
+futures = "0.3.31"
+log = "0.4.29"
+sdre-rust-logging = "0.3.27"
+sdre-stubborn-io = "0.7.1"
+tmq = "0.5.0"
+tokio = { version = "1.52.2", features = ["full", "tracing"] }
+tokio-stream = "0.1.18"
+tokio-util = { version = "0.7.18", features = ["full"] }
+zmq = "0.10.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -68,7 +68,7 @@ async fn main() -> Result<()> {
     info!("Creating input server");
     match SocketType::try_from(config.get_source_protocol()) {
         Ok(SocketType::Tcp) => {
-            let input_server = InputServerOptions::<StubbornIo<TcpStream, String>>::new(
+            let input_server = InputServerOptions::<StubbornIo<TcpStream>>::new(
                 config.get_source_host(),
                 config.get_source_port(),
                 input,
@@ -125,8 +125,7 @@ async fn main() -> Result<()> {
         match SocketType::try_from(proto) {
             Ok(SocketType::Tcp) => {
                 let output_server =
-                    OutputServerOptions::<StubbornIo<TcpStream, String>>::new(&host, port, output)
-                        .await?;
+                    OutputServerOptions::<StubbornIo<TcpStream>>::new(&host, port, output).await?;
 
                 tokio::spawn(async move {
                     output_server.watch_queue().await;

--- a/src/tcp.rs
+++ b/src/tcp.rs
@@ -4,16 +4,18 @@
 // Permission is granted to use, copy, modify, and redistribute the work.
 // Full license information available in the project LICENSE file.
 
-use anyhow::{Error, Result};
+use anyhow::{Error, Result, anyhow};
 use async_trait::async_trait;
 use sdre_stubborn_io::ReconnectOptions;
 use sdre_stubborn_io::StubbornTcpStream;
 use sdre_stubborn_io::config::DurationIterator;
 use sdre_stubborn_io::tokio::StubbornIo;
+use std::net::SocketAddr;
 use std::time::Duration;
 use tokio::io::AsyncWriteExt;
 use tokio::io::BufWriter;
 use tokio::net::TcpStream;
+use tokio::net::lookup_host;
 use tokio::sync::mpsc::{Receiver, Sender};
 use tokio_stream::StreamExt;
 use tokio_util::codec::{Framed, LinesCodec};
@@ -23,17 +25,38 @@ use crate::serverconfig::InputServerOptions;
 use crate::serverconfig::OutputServer;
 use crate::serverconfig::OutputServerOptions;
 
+/// Resolve a `host:port` pair into the first available `SocketAddr`.
+///
+/// `sdre-stubborn-io` 0.7 narrowed `StubbornTcpStream` to take a `SocketAddr`
+/// only, pushing DNS responsibility onto the caller. We resolve once at
+/// connect time; if the destination's DNS changes during a long-running
+/// session the cached `SocketAddr` will be stale. Pre-resolving is the
+/// "bare `SocketAddr`" path explicitly called out as acceptable in the
+/// crate's 0.7.1 migration notes.
+async fn resolve_host(host: &str, port: u16) -> Result<SocketAddr, Error> {
+    let target = format!("{host}:{port}");
+    lookup_host(&target)
+        .await?
+        .next()
+        .ok_or_else(|| anyhow!("No addresses resolved for {target}"))
+}
+
 #[async_trait]
-impl InputServer for InputServerOptions<StubbornIo<TcpStream, String>> {
+impl InputServer for InputServerOptions<StubbornIo<TcpStream>> {
     async fn new(
         host: &str,
         port: u16,
         sender: Option<Sender<String>>,
         stats: Sender<u8>,
     ) -> Result<Self, Error> {
+        let addr = match resolve_host(host, port).await {
+            Ok(addr) => addr,
+            Err(e) => panic!("[TCP Input {host}:{port}] DNS resolution failed: {e}"),
+        };
+
         let stream = match StubbornTcpStream::connect_with_options(
-            format!("{host}:{port}"),
-            reconnect_options(format!("{host}:{port}").as_str()),
+            addr,
+            reconnect_options(&format!("{host}:{port}")),
         )
         .await
         {
@@ -83,11 +106,16 @@ impl InputServer for InputServerOptions<StubbornIo<TcpStream, String>> {
 }
 
 #[async_trait]
-impl OutputServer for OutputServerOptions<StubbornIo<TcpStream, String>> {
+impl OutputServer for OutputServerOptions<StubbornIo<TcpStream>> {
     async fn new(host: &str, port: u16, receiver: Receiver<String>) -> Result<Self, Error> {
-        let stream: StubbornIo<TcpStream, String> = match StubbornTcpStream::connect_with_options(
-            format!("{host}:{port}"),
-            reconnect_options(format!("{host}:{port}").as_str()),
+        let addr = match resolve_host(host, port).await {
+            Ok(addr) => addr,
+            Err(e) => panic!("[TCP Output {host}:{port}] DNS resolution failed: {e}"),
+        };
+
+        let stream: StubbornIo<TcpStream> = match StubbornTcpStream::connect_with_options(
+            addr,
+            reconnect_options(&format!("{host}:{port}")),
         )
         .await
         {
@@ -108,7 +136,7 @@ impl OutputServer for OutputServerOptions<StubbornIo<TcpStream, String>> {
 
     async fn watch_queue(mut self) {
         let name = self.format_name();
-        let mut writer: BufWriter<StubbornIo<TcpStream, String>> = BufWriter::new(self.socket);
+        let mut writer: BufWriter<StubbornIo<TcpStream>> = BufWriter::new(self.socket);
         while let Some(line) = self.receiver.recv().await {
             debug!("{name}Received: {line}");
 
@@ -143,8 +171,9 @@ impl OutputServer for OutputServerOptions<StubbornIo<TcpStream, String>> {
 }
 
 pub fn reconnect_options(host: &str) -> ReconnectOptions {
+    // `with_exit_if_first_connect_fails(false)` is the default in 0.7 and has
+    // been dropped from this builder chain accordingly.
     ReconnectOptions::new()
-        .with_exit_if_first_connect_fails(false)
         .with_retries_generator(get_our_standard_reconnect_strategy)
         .with_connection_name(host)
 }


### PR DESCRIPTION
## Summary

`sdre-stubborn-io` 0.7 made two breaking changes that affected this crate:

- `UnderlyingIo` lost its generic constructor parameter and gained an associated `Context` type. `StubbornIo<T, C>` is now `StubbornIo<T>`.
- `StubbornTcpStream::connect_with_options` takes a `SocketAddr` only — DNS responsibility was intentionally pushed onto the caller.

## Changes

- `src/tcp.rs`: drop the second generic argument from `StubbornIo<TcpStream, String>`; add a `resolve_host()` helper that uses `tokio::net::lookup_host` to pre-resolve `host:port` to a `SocketAddr` before connecting; remove `.with_exit_if_first_connect_fails(false)` (now the default in 0.7).
- `src/main.rs`: update the `InputServerOptions` / `OutputServerOptions` turbofish call sites to the single-generic form.

## Trade-off

Pre-resolving caches the `SocketAddr` for the connection lifetime, so a destination whose DNS changes mid-session won't be re-resolved on reconnect. The upstream changelog calls this out as acceptable for simple consumers; if acars-bridge ever needs DNS-on-reconnect the next step is a custom `UnderlyingIo` impl per the skeleton in `sdre-stubborn-io`'s CHANGELOG.

## Verification

- `cargo build` clean
- `cargo clippy --all-targets -- -D warnings` clean
- pre-commit hooks pass