### PR TITLE
ci: adopt s6 runtime verification

### DIFF
--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   test_build:
     name: Test Image Build
-    uses: sdr-enthusiasts/common-github-workflows/.github/workflows/sdre.yml@bcf0b94a192e7ca9630f788ecc16acd999541404 # main
+    uses: sdr-enthusiasts/common-github-workflows/.github/workflows/sdre.yml@4cf063e5906338b3b92f0fe71d8dbae52c180d99 # main
     with:
       push_enabled: false
       ghcr_repo_owner: ${{ github.repository_owner }}

--- a/.github/workflows/test_build.yml
+++ b/.github/workflows/test_build.yml
@@ -14,6 +14,12 @@ jobs:
       ghcr_repo_owner: ${{ github.repository_owner }}
       ghcr_repo: ${{ github.repository }}
       docker_build_file: Dockerfile.build_binary
+      # Dockerfile.build_binary is a build environment, not a runnable service
+      # container: its final stage is FROM scratch holding only the compiled
+      # binary, which other images COPY out. There is no s6-overlay, no service
+      # graph, and no runtime to assert anything about, so the verification is
+      # not applicable here rather than merely inconvenient.
+      verify_s6_enabled: false
     secrets:
       ghcr_token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
ci: adopt s6 runtime verification

Bumps the sdre.yml pin so builds are verified against the image's s6
service graph before the manifest is published, rather than only being
checked for having built. This repo passes none of the inputs removed
upstream, so no other workflow change is needed.
